### PR TITLE
upgrade to aurora-mysql8.0

### DIFF
--- a/rds-with-proxy.yaml
+++ b/rds-with-proxy.yaml
@@ -12,9 +12,9 @@ Mappings:
   ClusterSettings:
     global:
       dbSchema: mylab
-      dbVersion: 5.7.mysql_aurora.2.09.1
+      dbVersion: 8.0.mysql_aurora.3.07.0
       dbEngine: aurora-mysql
-      dbFamily: aurora-mysql5.7
+      dbFamily: aurora-mysql8.0
       port: 3306
       nodeType: db.r5.large
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Mysql 5.7 no longer supported. Upgrade SAM template to Aurora MySQL 8.0
dbVersion: 8.0.mysql_aurora.3.07.0
dbFamily: aurora-mysql8.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
